### PR TITLE
keyindex: op=index skips revoked UATs

### DIFF
--- a/keyindex.c
+++ b/keyindex.c
@@ -270,6 +270,34 @@ int list_sigs(struct onak_dbctx *dbctx,
 	return 0;
 }
 
+/*
+ * Returns true if the given signed packet (a UID or a UAT) carries a
+ * v4/v5 certification revocation signature (sigtype 0x30) — i.e. the
+ * signed packet has been revoked. Doesn't try to authenticate which key
+ * issued the revocation (the same heuristic the rest of keyindex.c
+ * applies); enough for the display-time filtering done by op=index.
+ */
+static bool signedpacket_is_revoked(struct openpgp_signedpacket_list *sp)
+{
+	struct openpgp_packet_list *sigs;
+
+	if (sp == NULL) {
+		return false;
+	}
+	for (sigs = sp->sigs; sigs != NULL; sigs = sigs->next) {
+		if (sigs->packet == NULL || sigs->packet->data == NULL ||
+				sigs->packet->length < 2) {
+			continue;
+		}
+		if ((sigs->packet->data[0] == 4 ||
+				sigs->packet->data[0] == 5) &&
+				sigs->packet->data[1] == 0x30) {
+			return true;
+		}
+	}
+	return false;
+}
+
 int list_uids(struct onak_dbctx *dbctx,
 		uint64_t keyid, struct openpgp_signedpacket_list *uids,
 		bool verbose, bool html)
@@ -294,6 +322,18 @@ int list_uids(struct onak_dbctx *dbctx,
 					uids->packet->data);
 			}
 		} else if (uids->packet->tag == OPENPGP_PACKET_UAT) {
+			/*
+			 * In op=index mode (verbose=false), revoked UATs are
+			 * skipped: a photo whose owner has revoked it clutters
+			 * the listing and isn't part of what the user
+			 * currently asserts about themselves. op=vindex
+			 * (verbose=true) still shows every UAT, since its
+			 * purpose is the full key state including history.
+			 */
+			if (!verbose && signedpacket_is_revoked(uids)) {
+				uids = uids->next;
+				continue;
+			}
 			printf("                                ");
 			if (html) {
 				printf("<img src=\"lookup?op=photo&search="

--- a/keyindex.c
+++ b/keyindex.c
@@ -329,7 +329,17 @@ int list_uids(struct onak_dbctx *dbctx,
 			 * currently asserts about themselves. op=vindex
 			 * (verbose=true) still shows every UAT, since its
 			 * purpose is the full key state including history.
+			 *
+			 * imgindx is captured *before* the skip and always
+			 * incremented, because op=photo's getphoto() iterates
+			 * over every UAT in the key (revoked or not) and
+			 * counts them with the same stride. Leaving skipped
+			 * UATs out of the count would desync the HTML idx=N
+			 * we emit from the index getphoto() looks up — making
+			 * the browser fetch the wrong (typically: revoked)
+			 * photo blob for what is shown as the valid UAT.
 			 */
+			int this_idx = imgindx++;
 			if (!verbose && signedpacket_is_revoked(uids)) {
 				uids = uids->next;
 				continue;
@@ -340,8 +350,7 @@ int list_uids(struct onak_dbctx *dbctx,
 					"0x%016" PRIX64 "&idx=%d\" alt=\""
 					"[photo id]\">\n",
 					keyid,
-					imgindx);
-				imgindx++;
+					this_idx);
 			} else {
 				printf("[photo id]\n");
 			}

--- a/keyindex.c
+++ b/keyindex.c
@@ -291,7 +291,8 @@ static bool signedpacket_is_revoked(struct openpgp_signedpacket_list *sp)
 		}
 		if ((sigs->packet->data[0] == 4 ||
 				sigs->packet->data[0] == 5) &&
-				sigs->packet->data[1] == 0x30) {
+				sigs->packet->data[1] ==
+					OPENPGP_SIGTYPE_CERT_REV) {
 			return true;
 		}
 	}
@@ -330,30 +331,30 @@ int list_uids(struct onak_dbctx *dbctx,
 			 * (verbose=true) still shows every UAT, since its
 			 * purpose is the full key state including history.
 			 *
-			 * imgindx is captured *before* the skip and always
-			 * incremented, because op=photo's getphoto() iterates
-			 * over every UAT in the key (revoked or not) and
-			 * counts them with the same stride. Leaving skipped
-			 * UATs out of the count would desync the HTML idx=N
-			 * we emit from the index getphoto() looks up — making
+			 * imgindx is incremented for every UAT (revoked or
+			 * not), because op=photo's getphoto() iterates over
+			 * them all with the same stride. Leaving skipped UATs
+			 * out of the count would desync the HTML idx=N we
+			 * emit from the index getphoto() looks up — making
 			 * the browser fetch the wrong (typically: revoked)
 			 * photo blob for what is shown as the valid UAT.
 			 */
-			int this_idx = imgindx++;
 			if (!verbose && signedpacket_is_revoked(uids)) {
-				uids = uids->next;
-				continue;
-			}
-			printf("                                ");
-			if (html) {
-				printf("<img src=\"lookup?op=photo&search="
-					"0x%016" PRIX64 "&idx=%d\" alt=\""
-					"[photo id]\">\n",
-					keyid,
-					this_idx);
+				/* skip in op=index ; nothing to print */
 			} else {
-				printf("[photo id]\n");
+				printf("                                ");
+				if (html) {
+					printf("<img src=\"lookup?op=photo&"
+						"search=0x%016" PRIX64
+						"&idx=%d\" alt=\""
+						"[photo id]\">\n",
+						keyid,
+						imgindx);
+				} else {
+					printf("[photo id]\n");
+				}
 			}
+			imgindx++;
 		}
 		if (verbose) {
 			list_sigs(dbctx, uids->sigs, html);


### PR DESCRIPTION
Small focused change. When a key has a User Attribute Packet (typically a JPEG photo) that the owner has revoked with a certification revocation (sigtype `0x30`), `op=index` keeps showing it as a `[photo id]` line. In the compact public listing, this is visual noise — the photo is no longer part of what the owner currently asserts.

The patch filters revoked UATs out of `op=index` only. `op=vindex` is intentionally unchanged: its purpose is the full audit view, where the revoked UAT and its `rev` signatures remain informative.

Detection uses the same heuristic the rest of `keyindex.c` already applies for sig revocations (signature version 4 or 5, sigtype `0x30`). No attempt to authenticate which key issued the revocation — the listing is a display, not a trust decision.

One static helper added (`signedpacket_is_revoked`), 40 lines including comments. Compiles clean (CMake build with no new warnings).

Submitted on behalf of [foopgp](https://foopgp.org/) (Friends of OpenPGP), which runs onak at <https://keys.foopgp.org/>. A short presentation email will follow.